### PR TITLE
using okhttp3 instead of plain old HttpURLConnection from JDK.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <joda-time.version>2.9.9</joda-time.version>
         <json.version>20160810</json.version>
         <junit.version>4.4</junit.version>
+        <okhttp.version>3.8.0</okhttp.version>
         <artifact.name>pinterest4j-core</artifact.name>
     </properties>
 
@@ -37,6 +38,13 @@
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/pinterest4j/util/exception/PinterestException.java
+++ b/src/main/java/pinterest4j/util/exception/PinterestException.java
@@ -37,10 +37,14 @@ public class PinterestException extends Exception {
     }
 
     public PinterestException(String message, int statusCode) {
-        this(message, statusCode, null);
+        this(statusCode, message, null);
     }
 
-    public PinterestException(String message, int statusCode, Throwable cause) {
+    public PinterestException(int statusCode, String message) {
+        this(statusCode, message, null);
+    }
+
+    public PinterestException(int statusCode, String message, Throwable cause) {
         super(message, cause);
         this.message = getErrorMessage(message);
         this.statusCode = statusCode;

--- a/src/main/java/pinterest4j/util/exception/PinterestException.java
+++ b/src/main/java/pinterest4j/util/exception/PinterestException.java
@@ -36,10 +36,6 @@ public class PinterestException extends Exception {
         this(message, null);
     }
 
-    public PinterestException(String message, int statusCode) {
-        this(statusCode, message, null);
-    }
-
     public PinterestException(int statusCode, String message) {
         this(statusCode, message, null);
     }

--- a/src/main/java/pinterest4j/util/http/HttpClientImpl.java
+++ b/src/main/java/pinterest4j/util/http/HttpClientImpl.java
@@ -16,16 +16,11 @@
 
 package pinterest4j.util.http;
 
+import okhttp3.*;
 import org.json.JSONObject;
 import pinterest4j.util.exception.PinterestException;
 
-import java.io.*;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Client for making HTTP calls
@@ -33,6 +28,8 @@ import java.util.Map;
  * Created by Aniket Divekar.
  */
 public class HttpClientImpl implements HttpClient {
+
+    private static final OkHttpClient client = new OkHttpClient.Builder().build();
 
     @Override
     public HttpResponse get(String requestUrl) throws PinterestException {
@@ -55,88 +52,22 @@ public class HttpClientImpl implements HttpClient {
     }
 
     private HttpResponse request(String requestUrl, String method, QueryParam[] params) throws PinterestException {
-
         try {
+            // build the request
+            Request request = new Request.Builder().url(new URL(requestUrl))
+                    .method(method, getRequestBody(method, params)).build();
 
-            URL url = new URL(requestUrl);
-            HttpURLConnection con = (HttpURLConnection) url.openConnection();
-            con.addRequestProperty("Accept-Charset", "UTF-8");
-            con.setDoInput(true);
-            con.setRequestMethod(method);
-            con.setUseCaches(false);
-            OutputStream outputStream = null;
+            // execute the request
+            Response response = client.newCall(request).execute();
 
-            if (!"GET".equalsIgnoreCase(method) && params != null) {
-                try {
-                    if (QueryParam.containsFile(params)) {
-                        String boundary = "----pinterest4J-file-upload" + System.currentTimeMillis();
-                        con.setRequestProperty("Content-Type", HttpUtil.CONTENT_TYPE_MULTIPART + "; boundary=" + boundary);
-                        boundary = "--" + boundary;
-                        con.setDoOutput(true);
-                        outputStream = con.getOutputStream();
-                        DataOutputStream out = new DataOutputStream(outputStream);
-                        for (QueryParam param : params) {
-                            if (param.isFile()) {
-                                out.writeBytes(boundary + "\r\n");
-                                out.writeBytes("Content-Disposition: form-data; name=\"" + param.getKey() + "\"; filename=\"" + param.getFile().getName() + "\"\r\n");
-                                out.writeBytes("Content-Type: " + param.getContentType() + "\r\n\r\n");
-                                BufferedInputStream in = new BufferedInputStream( new FileInputStream(param.getFile()));
-                                byte[] buff = new byte[1024];
-                                int length;
-                                while ((length = in.read(buff)) != -1) {
-                                    out.write(buff, 0, length);
-                                    //sb.append(new String(buff));
-                                }
-                                out.writeBytes( "\r\n");
-                                in.close();
-                            } else if (param.getValue() != null){
-                                out.writeBytes(boundary + "\r\n");
-                                out.writeBytes( "Content-Disposition: form-data; name=\"" + param.getKey() + "\"\r\n");
-                                out.writeBytes( "Content-Type: " + HttpUtil.CONTENT_TYPE_TEXT + "\r\n\r\n");
-                                out.write(param.getValue().getBytes("UTF-8"));
-                                out.writeBytes( "\r\n");
-                            }
-                        }
-                        out.writeBytes( boundary + "--\r\n");
-                        out.writeBytes( "\r\n");
-
-                    } else {
-                        con.setRequestProperty("Content-Type", HttpUtil.CONTENT_TYPE_FORM);
-                        String postParam = UrlEncodeUtil.encodeParams(params);
-                        byte[] bytes = postParam.getBytes("UTF-8");
-                        con.setRequestProperty("Content-Length", Integer.toString(bytes.length));
-                        con.setDoOutput(true);
-                        outputStream = con.getOutputStream();
-                        outputStream.write(bytes);
-                    }
-                    outputStream.flush();
-                    outputStream.close();
-
-                } finally {
-                    if (outputStream != null) {
-                        outputStream.close();
-                    }
-                }
-            }
-
-            int statusCode = con.getResponseCode();
-            BufferedReader in;
-
-            if (statusCode < HttpURLConnection.HTTP_OK || statusCode >= HttpURLConnection.HTTP_MOVED_PERM) {
+            if (!response.isSuccessful()) {
                 // non-ok response
-                return HttpUtil.handleNonOkResponse(con.getErrorStream(), statusCode);
+                throw new PinterestException(response.message(), response.code());
             }
 
-            in = new BufferedReader(new InputStreamReader(con.getInputStream(), "UTF-8"));
+            final String resp = response.body().string();
 
-            String resp = HttpUtil.getResponseAsString(in);
-
-            Map<String, List<String>> headerFields = con.getHeaderFields();
-
-            // close the stream
-            in.close();
-
-            return new HttpResponse(statusCode, resp, new JSONObject(resp), headerFields);
+            return new HttpResponse(response.code(), resp, new JSONObject(resp), response.headers().toMultimap());
 
         } catch (Exception e) {
             // log error
@@ -145,36 +76,25 @@ public class HttpClientImpl implements HttpClient {
         }
     }
 
-    /*
-     * Workaround for a bug in {@code HttpURLConnection.setRequestMethod(String)}
-     * The implementation of Sun/Oracle is throwing a {@code ProtocolException}
-     * when the method is other than the HTTP/1.1 default methods. So to use {@code PROPFIND}
-     * and others, we must apply this workaround.
-     *
-     * See issue http://java.net/jira/browse/JERSEY-639
-     */
+    private RequestBody getRequestBody(String method, QueryParam[] params) {
+        RequestBody body = null;
 
-    static {
-        try {
-            Field methodsField = HttpURLConnection.class.getDeclaredField("methods");
-            methodsField.setAccessible(true);
-            // get the methods field modifiers
-            Field modifiersField = Field.class.getDeclaredField("modifiers");
-            // bypass the "private" modifier
-            modifiersField.setAccessible(true);
-
-            // remove the "final" modifier
-            modifiersField.setInt(methodsField, methodsField.getModifiers() & ~Modifier.FINAL);
-
-            /* valid HTTP methods */
-            String[] methods = {
-                    "GET", "POST", "HEAD", "OPTIONS", "PUT", "DELETE", "TRACE", "PATCH"
-            };
-            // set the new methods - including patch
-            methodsField.set(null, methods);
-
-        } catch (IllegalArgumentException | NoSuchFieldException | IllegalAccessException e) {
-            throw new ExceptionInInitializerError(e);
+        if (!HttpRequestMethods.GET.name().equalsIgnoreCase(method) && params != null) {
+            if (QueryParam.containsFile(params)) {
+                MultipartBody.Builder builder = new MultipartBody.Builder();
+                for (QueryParam param : params) {
+                    if (param.isFile()) {
+                        builder.addFormDataPart(param.getKey(), param.getFile().getName(), RequestBody.create(MediaType.parse(param.getContentType()), param.getFile()));
+                    } else {
+                        builder.addFormDataPart(param.getKey(), param.getValue());
+                    }
+                }
+                body = builder.build();
+            } else {
+                body = RequestBody.create(MediaType.parse(HttpUtil.CONTENT_TYPE_FORM), UrlEncodeUtil.encodeParams(params));
+            }
         }
+
+        return body;
     }
 }

--- a/src/main/java/pinterest4j/util/http/HttpClientImpl.java
+++ b/src/main/java/pinterest4j/util/http/HttpClientImpl.java
@@ -81,11 +81,11 @@ public class HttpClientImpl implements HttpClient {
 
         if (!HttpRequestMethods.GET.name().equalsIgnoreCase(method) && params != null) {
             if (QueryParam.containsFile(params)) {
-                MultipartBody.Builder builder = new MultipartBody.Builder();
+                MultipartBody.Builder builder = new MultipartBody.Builder().setType(MediaType.parse(HttpUtil.CONTENT_TYPE_MULTIPART));
                 for (QueryParam param : params) {
                     if (param.isFile()) {
                         builder.addFormDataPart(param.getKey(), param.getFile().getName(), RequestBody.create(MediaType.parse(param.getContentType()), param.getFile()));
-                    } else {
+                    } else if (param.getValue() != null){
                         builder.addFormDataPart(param.getKey(), param.getValue());
                     }
                 }

--- a/src/main/java/pinterest4j/util/http/HttpClientImpl.java
+++ b/src/main/java/pinterest4j/util/http/HttpClientImpl.java
@@ -16,7 +16,12 @@
 
 package pinterest4j.util.http;
 
-import okhttp3.*;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 import org.json.JSONObject;
 import pinterest4j.util.exception.PinterestException;
 

--- a/src/main/java/pinterest4j/util/http/HttpClientImpl.java
+++ b/src/main/java/pinterest4j/util/http/HttpClientImpl.java
@@ -67,7 +67,7 @@ public class HttpClientImpl implements HttpClient {
 
             if (!response.isSuccessful()) {
                 // non-ok response
-                throw new PinterestException(response.message(), response.code());
+                throw new PinterestException(response.code(), response.message());
             }
 
             final String resp = response.body().string();

--- a/src/main/java/pinterest4j/util/http/HttpUtil.java
+++ b/src/main/java/pinterest4j/util/http/HttpUtil.java
@@ -24,6 +24,7 @@ package pinterest4j.util.http;
 public final class HttpUtil {
 
     public final static String CONTENT_TYPE_FORM = "application/x-www-form-urlencoded;charset=UTF-8";
+    public final static String CONTENT_TYPE_MULTIPART = "multipart/form-data";
     public static final String CONTENT_TYPE_JPEG = "image/jpeg";
     public static final String CONTENT_TYPE_GIF = "image/gif";
     public static final String CONTENT_TYPE_PNG = "image/png";

--- a/src/main/java/pinterest4j/util/http/HttpUtil.java
+++ b/src/main/java/pinterest4j/util/http/HttpUtil.java
@@ -16,48 +16,17 @@
 
 package pinterest4j.util.http;
 
-import pinterest4j.util.exception.PinterestException;
-
-import javax.net.ssl.HttpsURLConnection;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-
 /**
- * Utility for handling http response from {@link HttpsURLConnection#getInputStream()}, {@link HttpsURLConnection#getErrorStream()}
+ * Constants for HTTP requests
  *
  * Created by Aniket Divekar.
  */
-public class HttpUtil {
+public final class HttpUtil {
 
     public final static String CONTENT_TYPE_FORM = "application/x-www-form-urlencoded;charset=UTF-8";
-    public final static String CONTENT_TYPE_MULTIPART = "multipart/form-data";
-    public final static String CONTENT_TYPE_JSON = "application/json";
     public static final String CONTENT_TYPE_JPEG = "image/jpeg";
     public static final String CONTENT_TYPE_GIF = "image/gif";
     public static final String CONTENT_TYPE_PNG = "image/png";
     public static final String CONTENT_TYPE_OCTET = "application/octet-stream";
-    public static final String CONTENT_TYPE_TEXT = "text/plain;charset=UTF-8";
 
-    public static String getResponseAsString(BufferedReader in) throws IOException {
-        String inputLine;
-        StringBuilder response = new StringBuilder();
-
-        while ((inputLine = in.readLine()) != null) {
-            response.append(inputLine);
-        }
-
-        return response.toString();
-    }
-
-    public static HttpResponse handleNonOkResponse(InputStream in, int statusCode) throws IOException, PinterestException {
-        BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
-        String resp = HttpUtil.getResponseAsString(br);
-
-        // close the stream
-        br.close();
-
-        throw new PinterestException(resp, statusCode);
-    }
 }


### PR DESCRIPTION
Using okhttp3 instead of plain old HttpURLConnection from JDK.

**Why?** 

_The main intention of using the client is because HttpURLConnection from JDK does not allow `PATCH` request and it required to modify the allowed methods using reflection in HttpURLConnection, which I thought isn't a good idea._

**_Here is the [ISSUE](https://bugs.openjdk.java.net/browse/JDK-7016595) which says that Oracle is not going to fix this._**

I checked two options:
- [Apache HttpCore](https://github.com/apache/httpcomponents-core)
- [okhttp3](https://github.com/square/okhttp)

The latter has more contributors and being widely used in comparison to former. 